### PR TITLE
Fix module imports in tests

### DIFF
--- a/src/quantum_classical_interface.py
+++ b/src/quantum_classical_interface.py
@@ -1,0 +1,13 @@
+"""Convenience wrapper for the core quantum_classical_interface module."""
+
+import os
+import sys
+
+# Ensure the package in ``src`` is importable when the project is not installed.
+_src_path = os.path.join(os.path.dirname(__file__), "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+from quantum_consciousness.core.quantum_classical_interface import *
+
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/quantum_cup_product.py
+++ b/src/quantum_cup_product.py
@@ -1,0 +1,12 @@
+"""Convenience wrapper for the core quantum_cup_product module."""
+
+import os
+import sys
+
+_src_path = os.path.join(os.path.dirname(__file__), "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+from quantum_consciousness.core.quantum_cup_product import *
+
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/quantum_gns_construction.py
+++ b/src/quantum_gns_construction.py
@@ -1,0 +1,12 @@
+"""Convenience wrapper for the core quantum_gns_construction module."""
+
+import os
+import sys
+
+_src_path = os.path.join(os.path.dirname(__file__), "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+from quantum_consciousness.core.quantum_gns_construction import *
+
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/quantum_hybrid_cognitive.py
+++ b/src/quantum_hybrid_cognitive.py
@@ -1,0 +1,12 @@
+"""Convenience wrapper for the core quantum_hybrid_cognitive module."""
+
+import os
+import sys
+
+_src_path = os.path.join(os.path.dirname(__file__), "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+from quantum_consciousness.core.quantum_hybrid_cognitive import *
+
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/quantum_information_geometry.py
+++ b/src/quantum_information_geometry.py
@@ -1,0 +1,12 @@
+"""Convenience wrapper for the core quantum_information_geometry module."""
+
+import os
+import sys
+
+_src_path = os.path.join(os.path.dirname(__file__), "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+from quantum_consciousness.core.quantum_information_geometry import *
+
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/quantum_topology.py
+++ b/src/quantum_topology.py
@@ -1,0 +1,12 @@
+"""Convenience wrapper for the core quantum_topology module."""
+
+import os
+import sys
+
+_src_path = os.path.join(os.path.dirname(__file__), "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+from quantum_consciousness.core.quantum_topology import *
+
+__all__ = [name for name in globals() if not name.startswith("_")]


### PR DESCRIPTION
## Summary
- expose core modules at the top level by creating wrapper modules under `src`
- wrappers automatically add the project `src` directory to `sys.path`

## Testing
- `PYTHONPATH=src pytest src/quantum_consciousness/core/test_quantum_information_geometry.py::test_fubini_study_metric -q`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_684a0a7a5578832897b7870889e0360c