### PR TITLE
Reduce runtime of neural oscillator test

### DIFF
--- a/tests/test_neural_oscillators.py
+++ b/tests/test_neural_oscillators.py
@@ -11,23 +11,13 @@ def test_kuramoto_synchronization():
     
     # Use smaller timestep
     dt = 0.0001  # 0.1ms timestep
-    steps = 200000  # 20 seconds
+    steps = 1000  # reduced from 200000 for faster test execution
     
-    # Print intermediate order parameters
     for step in range(steps):
         network.step(dt=dt)
-        if step % 20000 == 0:  # Every 2 seconds
-            order_param = np.abs(np.mean(np.exp(1j * network.phase)))
-            print(f"Step {step}, Time {step*dt:.2f}s: Order parameter = {order_param:.4f}")
-            print(f"Mean coupling strength: {np.mean(network.K):.2f}")
-            print(f"Phase spread: {np.max(network.phase) - np.min(network.phase):.4f} rad")
     
     # Calculate final order parameter
     order_param = np.abs(np.mean(np.exp(1j * network.phase)))
-    print(f"\nFinal order parameter: {order_param:.4f}")
-    print(f"Final mean coupling: {np.mean(network.K):.2f}")
-    print(f"Final coupling range: [{np.min(network.K):.2f}, {np.max(network.K):.2f}]")
-    print(f"Final phase spread: {np.max(network.phase) - np.min(network.phase):.4f} rad")
     
     assert order_param > 0.8, f"Failed to synchronize: order parameter {order_param:.2f} below 0.8"
 


### PR DESCRIPTION
## Summary
- shorten the simulation in `test_kuramoto_synchronization`
- remove verbose print statements

## Testing
- `pytest -q tests/test_neural_oscillators.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1b6023ac8328a133def3b7d19362