### PR TITLE
Fix measurement probability normalization

### DIFF
--- a/src/quantum_consciousness/core/quantum_classical_interface.py
+++ b/src/quantum_consciousness/core/quantum_classical_interface.py
@@ -46,6 +46,7 @@ class QuantumClassicalInterface:
         # Project state
         eigenvals, eigenvecs = np.linalg.eigh(observable)
         probabilities = np.abs(eigenvecs.conj().T @ quantum_state)**2
+        probabilities = probabilities / probabilities.sum()
 
         # Choose eigenstate based on probabilities
         outcome = np.random.choice(len(eigenvals), p=probabilities)


### PR DESCRIPTION
## Summary
- normalize probabilities when measuring

## Testing
- `pytest src/quantum_consciousness/core/test_quantum_classical_interface.py::test_quantum_measurement -q`
- `pytest -q` *(fails: cognitive fidelity and other unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b5e8a8c83288610248605e55136