### PR TITLE
Fix gauge transform indexing

### DIFF
--- a/src/quantum_consciousness/core/su3_lattice.py
+++ b/src/quantum_consciousness/core/su3_lattice.py
@@ -102,8 +102,8 @@ class SU3LatticeQCD:
                         
                         # Apply gauge transformation
                         self.gauge_field[i,j,k,mu] = (
-                            G @ self.gauge_field[i,j,k,mu] @ 
-                            G[ni,nj,nk].conj().T
+                            G @ self.gauge_field[i,j,k,mu] @
+                            G.conj().T
                         )
                         
     def compute_wilson_loop(self, size: Tuple[int, int]) -> complex:


### PR DESCRIPTION
## Summary
- avoid lattice indexing when applying SU(3) gauge transforms

## Testing
- `python - <<'PY'
from src.quantum_consciousness.core.su3_lattice import SU3LatticeQCD
import numpy as np
lattice = SU3LatticeQCD(lattice_size=2, spacing=0.1)
alpha = np.random.randn(8) * 0.1
lattice.gauge_transform(alpha)
print('gauge ok')
PY
`
- `pytest -q` *(fails: QuantumHybridCognitive.__init__() got unexpected keyword argument 'n_qubits', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b5c88908328add6dd3374969e58