### PR TITLE
Fix partial trace and cup product

### DIFF
--- a/src/quantum_consciousness/core/quantum_geometry.py
+++ b/src/quantum_consciousness/core/quantum_geometry.py
@@ -62,8 +62,7 @@ class QuantumGeometry:
     def quantum_cup_product(self, perception: np.ndarray, attention: np.ndarray,
                           memory: np.ndarray, beta: float) -> np.ndarray:
         """
-        Implement quantum cup product for cognitive architectures
-        a ∗_q b ≈ (Perception ∪ Attention)β q^{⟨β,ω⟩} (Memory)
+        Implement a simple quantum cup product used by ``QuantumSystem``.
 
         Args:
             perception: Quantum state representing perception
@@ -74,14 +73,16 @@ class QuantumGeometry:
         Returns:
             numpy.ndarray: Resulting quantum state
         """
-        # Calculate union of perception and attention
-        combined_state = np.kron(perception, attention)
+        perception = perception / np.linalg.norm(perception)
+        attention = attention / np.linalg.norm(attention)
+        memory = memory / np.linalg.norm(memory)
 
-        # Apply coupling with memory
-        omega = np.vdot(combined_state, memory)
-        coupling_factor = np.exp(beta * omega)
+        result = perception + attention + memory
+        phase = np.exp(1j * beta)
 
-        return coupling_factor * (combined_state @ memory)
+        result = phase * result
+        norm = np.linalg.norm(result)
+        return np.zeros_like(result) if norm == 0 else result / norm
 
     def tqft_boundary_map(self, initial_state: np.ndarray,
                          cobordism: np.ndarray) -> np.ndarray:

--- a/src/quantum_consciousness/core/test_quantum_topology.py
+++ b/src/quantum_consciousness/core/test_quantum_topology.py
@@ -134,12 +134,13 @@ def test_partial_trace():
     rho = np.outer(state, state.conj())
 
     # Compute partial trace
-    rho_A = qt._partial_trace(rho, [0, 1])
+    # Keep only the first qubit
+    rho_A = qt._partial_trace(rho, [0])
 
     # Test properties
     assert rho_A.shape == (2, 2)
     assert np.allclose(rho_A, rho_A.conj().T)  # Hermiticity
-    assert np.abs(np.trace(rho_A) - 1.0) < 1e-10  # Trace preservation
+    assert np.isclose(np.trace(rho_A), 1.0)
 
 def test_numerical_stability():
     """Test numerical stability of computations."""


### PR DESCRIPTION
## Summary
- fix cobordism matrix dimensions
- fix homology computations using `scipy.linalg.null_space`
- implement real partial trace instead of submatrix selection
- make geometry cup product consistent with system implementation
- adjust topology test for new partial trace

## Testing
- `pytest src/quantum_consciousness/core/test_quantum_topology.py::test_partial_trace -q`
- `pytest -q` *(fails: many tests from unrelated modules fail)*

------
https://chatgpt.com/codex/tasks/task_e_684a2510a718832881d3f02fcc8bd5c7